### PR TITLE
Add missing "page" class name

### DIFF
--- a/tabs/browse/browse.component.html
+++ b/tabs/browse/browse.component.html
@@ -2,7 +2,7 @@
 This is the component view that represents the 'Browse' tab.
 Feel free to customize layouts and components to change how the tab view looks.
 -->
-<GridLayout class="page-content" tkMainContent>
+<GridLayout class="page page-content" tkMainContent>
     <Label class="page-icon fa" text="&#xf1ea;"></Label>
     <Label class="page-placeholder" text="<!-- Page content goes here -->"></Label>
 </GridLayout>

--- a/tabs/featured/featured.component.html
+++ b/tabs/featured/featured.component.html
@@ -2,7 +2,7 @@
 This is the component view that represents the 'Featured' tab.
 Feel free to customize layouts and components to change how the tab view looks.
 -->
-<GridLayout class="page-content" tkMainContent>
+<GridLayout class="page page-content" tkMainContent>
     <Label class="page-icon fa" text="&#xf005;"></Label>
     <Label class="page-placeholder" text="<!-- Page content goes here -->"></Label>
 </GridLayout>

--- a/tabs/home/home.component.html
+++ b/tabs/home/home.component.html
@@ -2,7 +2,7 @@
 This is the component view that represents the 'Home' tab.
 Feel free to customize layouts and components to change how the tab view looks.
 -->
-<GridLayout class="page-content" tkMainContent>
+<GridLayout class="page page-content" tkMainContent>
     <Label class="page-icon fa" text="&#xf015;"></Label>
     <Label class="page-placeholder" text="<!-- Page content goes here -->"></Label>
 </GridLayout>

--- a/tabs/search/search.component.html
+++ b/tabs/search/search.component.html
@@ -2,7 +2,7 @@
 This is the component view that represents the 'Search' tab.
 Feel free to customize layouts and components to change how the tab view looks.
 -->
-<GridLayout class="page-content" tkMainContent>
+<GridLayout class="page page-content" tkMainContent>
     <Label class="page-icon fa" text="&#xf002;"></Label>
     <Label class="page-placeholder" text="<!-- Page content goes here -->"></Label>
 </GridLayout>

--- a/tabs/settings/settings.component.html
+++ b/tabs/settings/settings.component.html
@@ -2,7 +2,7 @@
 This is the component view that represents the 'Settings' tab.
 Feel free to customize layouts and components to change how the tab view looks.
 -->
-<GridLayout class="page-content" tkMainContent>
+<GridLayout class="page page-content" tkMainContent>
     <Label class="page-icon fa" text="&#xf013;"></Label>
     <Label class="page-placeholder" text="<!-- Page content goes here -->"></Label>
 </GridLayout>


### PR DESCRIPTION
The "page" class name is a theme class, used to change the background color of the main page content.